### PR TITLE
Add fill event logging to process_consume_events.

### DIFF
--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -16,6 +16,7 @@ default = ["program"]
 no-entrypoint = []
 
 [dependencies]
+anchor-lang = ">=0.24.2"
 solana-program = "1.6.18"
 spl-token = { version = "3.0.0-pre1", features = ["no-entrypoint"] }
 serde = "1.0.114"

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -1361,7 +1361,7 @@ pub struct FillEventLog {
     owner: Pubkey,
     owner_slot: u8,
     fee_tier: u8,
-    client_order_id: Option<NonZeroU64>,
+    client_order_id: Option<u64>,
 }
 
 #[derive(Copy, Clone)]
@@ -3054,7 +3054,10 @@ impl State {
                         owner: Pubkey::new(cast_slice(&identity(owner) as &[_])),
                         owner_slot,
                         fee_tier: fee_tier as u8,
-                        client_order_id,
+                        client_order_id: match client_order_id {
+                            Some(i) => Some(u64::from(i)),
+                            None => None,
+                        },
                     });
                 }
                 EventView::Out {

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -23,7 +23,7 @@ use spl_token::error::TokenError;
 
 use crate::{
     critbit::Slab,
-    error::{DexErrorCode, DexResult, SourceFileId, DexError},
+    error::{DexError, DexErrorCode, DexResult, SourceFileId},
     fees::{self, FeeTier},
     instruction::{
         disable_authority, fee_sweeper, msrm_token, srm_token, CancelOrderInstructionV2,
@@ -32,6 +32,8 @@ use crate::{
     },
     matching::{OrderBookState, OrderType, RequestProceeds, Side},
 };
+
+use anchor_lang::prelude::{borsh, emit, event, AnchorDeserialize, AnchorSerialize};
 
 declare_check_assert_macros!(SourceFileId::State);
 
@@ -1344,6 +1346,22 @@ impl EventView {
             &EventView::Fill { side, .. } | &EventView::Out { side, .. } => side,
         }
     }
+}
+
+#[event]
+pub struct FillEventLog {
+    market: Pubkey,
+    open_orders: Pubkey,
+    bid: bool,
+    maker: bool,
+    native_qty_paid: u64,
+    native_qty_received: u64,
+    native_fee_or_rebate: u64,
+    order_id: u128,
+    owner: Pubkey,
+    owner_slot: u8,
+    fee_tier: u8,
+    client_order_id: Option<NonZeroU64>,
 }
 
 #[derive(Copy, Clone)]
@@ -2912,7 +2930,7 @@ impl State {
                         }
                         return Err(err);
                     }
-                    _ => return Err(err)
+                    _ => return Err(err),
                 }
             }
         }
@@ -2960,15 +2978,20 @@ impl State {
             let owner: [u64; 4] = event.owner;
             let owner_index: Result<usize, usize> = open_orders_accounts
                 .binary_search_by_key(&owner, |account_info| account_info.key.to_aligned_bytes());
-            let mut open_orders: RefMut<OpenOrders> = match owner_index {
+            let mut open_orders: RefMut<OpenOrders>;
+            let open_orders_pubkey: &Pubkey;
+            match owner_index {
                 Err(_) => break,
-                Ok(i) => market.load_orders_mut(
-                    &open_orders_accounts[i],
-                    None,
-                    program_id,
-                    None,
-                    None,
-                )?,
+                Ok(i) => {
+                    open_orders = market.load_orders_mut(
+                        &open_orders_accounts[i],
+                        None,
+                        program_id,
+                        None,
+                        None,
+                    )?;
+                    open_orders_pubkey = &open_orders_accounts[i].key;
+                }
             };
 
             check_assert!(event.owner_slot < 128)?;
@@ -2985,9 +3008,9 @@ impl State {
                     native_qty_paid,
                     native_qty_received,
                     native_fee_or_rebate,
-                    fee_tier: _,
-                    order_id: _,
-                    owner: _,
+                    fee_tier,
+                    order_id,
+                    owner,
                     owner_slot,
                     client_order_id,
                 } => {
@@ -3015,6 +3038,24 @@ impl State {
                             identity(open_orders.client_order_ids[owner_slot as usize])
                         );
                     }
+
+                    emit!(FillEventLog {
+                        market: market.pubkey(),
+                        open_orders: *open_orders_pubkey,
+                        bid: match side {
+                            Side::Bid => true,
+                            Side::Ask => false,
+                        },
+                        maker,
+                        native_qty_paid,
+                        native_qty_received,
+                        native_fee_or_rebate,
+                        order_id,
+                        owner: Pubkey::new(cast_slice(&identity(owner) as &[_])),
+                        owner_slot,
+                        fee_tier: fee_tier as u8,
+                        client_order_id,
+                    });
                 }
                 EventView::Out {
                     side,


### PR DESCRIPTION
Add anchor event logging to process_consume_events to output filled trades when the program is cranked.