### PR TITLE
Allow library users to find orders by order id

### DIFF
--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -186,7 +186,6 @@ impl AnyNode {
         }
     }
 
-    #[cfg(test)]
     fn prefix_len(&self) -> u32 {
         match self.case().unwrap() {
             NodeRef::Inner(&InnerNode { prefix_len, .. }) => prefix_len,
@@ -599,8 +598,7 @@ impl Slab {
         }
     }
 
-    #[cfg(test)]
-    fn find_by_key(&self, search_key: u128) -> Option<NodeHandle> {
+    pub fn find_by_key(&self, search_key: u128) -> Option<NodeHandle> {
         let mut node_handle: NodeHandle = self.root()?;
         loop {
             let node_ref = self.get(node_handle).unwrap();


### PR DESCRIPTION
Mango v3/v4 need this to be able to determine if an order is cancelled before the event queue has been processed.