### PR TITLE
Change fee schedule

### DIFF
--- a/dex/fuzz/Cargo.lock
+++ b/dex/fuzz/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "serum_dex"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "arbitrary",
  "arrayref",

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -946,7 +946,7 @@ mod tests {
                         };
                         let owner = rng.gen();
                         let qty = rng.gen();
-                        let leaf = LeafNode::new(offset, key, owner, qty, FeeTier::SRM5, 5);
+                        let leaf = LeafNode::new(offset, key, owner, qty, FeeTier::Base, 5);
 
                         println!("Insert {:x}", key);
 

--- a/dex/src/fees.rs
+++ b/dex/src/fees.rs
@@ -104,12 +104,7 @@ impl FeeTier {
     }
 
     fn taker_rate(self) -> U64F64 {
-        use FeeTier::*;
-        match self {
-            Stable => fee_tenth_of_bps(10),
-            Flagship => fee_tenth_of_bps(40),
-            Base | _ => fee_tenth_of_bps(200),
-        }
+        self.maker_rate().mul_u64(2)
     }
 
     #[inline]

--- a/dex/src/fees.rs
+++ b/dex/src/fees.rs
@@ -27,8 +27,9 @@ pub enum FeeTier {
     _SRM4,
     _SRM5,
     _SRM6,
-    Flagship,
+    _MSRM,
     Stable,
+    Flagship,
 }
 
 #[repr(transparent)]

--- a/dex/src/fees.rs
+++ b/dex/src/fees.rs
@@ -5,24 +5,15 @@ use std::convert::TryInto;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 
+mod flagship_markets {
+    pub mod sol_usdc {
+        solana_program::declare_id!("8BnEgHoWFysVcuFFX7QztDmzuH8r5ZFvyP3sYwn1XTh6");
+    }
+}
+
 mod stable_markets {
     pub mod usdt_usdc {
         solana_program::declare_id!("B2na8Awyd7cpC59iEU43FagJAPLigr3AP3s38KM982bu");
-    }
-    pub mod msol_sol {
-        solana_program::declare_id!("5cLrMai1DsLRYc1Nio9qMTicsWtvzjzZfJPXyAoF4t1Z");
-    }
-    pub mod ust_usdc {
-        solana_program::declare_id!("EERNEEnBqdGzBS8dd46wwNY5F2kwnaCQ3vsq2fNKGogZ");
-    }
-    pub mod ust_usdt {
-        solana_program::declare_id!("8sFf9TW3KzxLiBXcDcjAxqabEsRroo4EiRr3UG1xbJ9m");
-    }
-    pub mod stsol_sol {
-        solana_program::declare_id!("2iDSTGhjJEiRxNaLF27CY6daMYPs5hgYrP2REHd5YD62");
-    }
-    pub mod usdh_usdc {
-        solana_program::declare_id!("CaFjigEgJdtGPxQxRjneA1hzNcY5MsHoAAL6Et67QrC5");
     }
 }
 
@@ -31,12 +22,12 @@ mod stable_markets {
 #[repr(u8)]
 pub enum FeeTier {
     Base,
-    SRM2,
-    SRM3,
-    SRM4,
-    SRM5,
-    SRM6,
-    MSRM,
+    _SRM2,
+    _SRM3,
+    _SRM4,
+    _SRM5,
+    _SRM6,
+    Flagship,
     Stable,
 }
 
@@ -83,61 +74,49 @@ const fn fee_tenth_of_bps(tenth_of_bps: u64) -> U64F64 {
     U64F64(((tenth_of_bps as u128) << 64) / 100_000)
 }
 
-#[inline(always)]
-const fn rebate_tenth_of_bps(tenth_of_bps: u64) -> U64F64 {
-    U64F64(fee_tenth_of_bps(tenth_of_bps).0 + 1)
-}
-
 impl FeeTier {
     #[inline]
-    pub fn from_srm_and_msrm_balances(market: &Pubkey, srm_held: u64, msrm_held: u64) -> FeeTier {
-        let one_srm = 1_000_000;
+    pub fn from_srm_and_msrm_balances(market: &Pubkey, _srm_held: u64, _msrm_held: u64) -> FeeTier {
+        if market == &flagship_markets::sol_usdc::ID {
+            return FeeTier::Flagship;
+        }
 
-        if market == &stable_markets::usdt_usdc::ID
-            || market == &stable_markets::msol_sol::ID
-            || market == &stable_markets::ust_usdc::ID
-            || market == &stable_markets::ust_usdt::ID
-            || market == &stable_markets::stsol_sol::ID
-            || market == &stable_markets::usdh_usdc::ID
-        {
+        if market == &stable_markets::usdt_usdc::ID {
             return FeeTier::Stable;
         }
 
-        match () {
-            () if msrm_held >= 1 => FeeTier::MSRM,
-            () if srm_held >= one_srm * 1_000_000 => FeeTier::SRM6,
-            () if srm_held >= one_srm * 100_000 => FeeTier::SRM5,
-            () if srm_held >= one_srm * 10_000 => FeeTier::SRM4,
-            () if srm_held >= one_srm * 1_000 => FeeTier::SRM3,
-            () if srm_held >= one_srm * 100 => FeeTier::SRM2,
-            () => FeeTier::Base,
+        FeeTier::Base
+    }
+
+    fn maker_rate(self) -> U64F64 {
+        use FeeTier::*;
+        match self {
+            Stable => fee_tenth_of_bps(5),
+            Flagship => fee_tenth_of_bps(20),
+            Base | _ => fee_tenth_of_bps(100),
         }
     }
 
     #[inline]
     pub fn maker_rebate(self, pc_qty: u64) -> u64 {
-        rebate_tenth_of_bps(0).mul_u64(pc_qty).floor()
+        let rate = self.maker_rate();
+        rate.mul_u64(pc_qty).floor()
     }
 
     fn taker_rate(self) -> U64F64 {
         use FeeTier::*;
         match self {
-            Base => fee_tenth_of_bps(40),
-            SRM2 => fee_tenth_of_bps(39),
-            SRM3 => fee_tenth_of_bps(38),
-            SRM4 => fee_tenth_of_bps(36),
-            SRM5 => fee_tenth_of_bps(34),
-            SRM6 => fee_tenth_of_bps(32),
-            MSRM => fee_tenth_of_bps(30),
             Stable => fee_tenth_of_bps(10),
+            Flagship => fee_tenth_of_bps(40),
+            Base | _ => fee_tenth_of_bps(200),
         }
     }
 
     #[inline]
     pub fn taker_fee(self, pc_qty: u64) -> u64 {
         let rate = self.taker_rate();
-        let exact_fee: U64F64 = rate.mul_u64(pc_qty);
-        exact_fee.floor() + ((exact_fee.frac_part() != 0) as u64)
+        let exact_fee = rate.mul_u64(pc_qty);
+        exact_fee.floor() + (exact_fee.frac_part() != 0) as u64
     }
 
     #[inline]
@@ -152,7 +131,7 @@ impl FeeTier {
 
 #[inline]
 pub fn referrer_rebate(amount: u64) -> u64 {
-    amount / 5
+    amount / 2
 }
 
 #[cfg(test)]
@@ -162,14 +141,13 @@ mod tests {
 
     proptest! {
         #[test]
-        fn positive_net_fees(tt: FeeTier, mt: FeeTier, qty in 1..=std::u64::MAX) {
-            let fee = tt.taker_fee(qty);
-            let rebate = mt.maker_rebate(qty) + referrer_rebate(fee);
-            assert!(fee > rebate);
-            let net_bps_u64f64 = (fee - rebate) as u128 * 100_000;
-            let three_bps = (qty as u128) * 3;
-            let dust_qty_u64f64 = 1 << 32;
-            assert!(net_bps_u64f64 + dust_qty_u64f64 > three_bps, "{:x}, {:x}, {:x}", qty, net_bps_u64f64, three_bps);
+        fn positive_net_fees(ft: FeeTier, qty in 1..=std::u64::MAX) {
+            let taker_fee = ft.taker_fee(qty);
+            let maker_rebate = ft.maker_rebate(qty);
+            let referrer_rebate = referrer_rebate(taker_fee);
+
+            assert!(referrer_rebate >= maker_rebate, "{:?}: {:?} >= {:?}", qty, referrer_rebate, maker_rebate);
+            assert!(taker_fee >= maker_rebate + referrer_rebate, "{:?}: {:?} >= {:?} + {:?}", qty, taker_fee, maker_rebate, referrer_rebate);
         }
 
         #[test]

--- a/dex/src/instruction.rs
+++ b/dex/src/instruction.rs
@@ -1203,6 +1203,7 @@ mod fuzzing {
                 client_order_id: value.client_order_id,
                 self_trade_behavior: value.self_trade_behavior,
                 limit: value.limit,
+                max_ts: i64::MAX,
             })
         }
     }

--- a/dex/src/tests.rs
+++ b/dex/src/tests.rs
@@ -343,8 +343,8 @@ fn test_new_order() {
 
     {
         let market = Market::load(&accounts.market, &dex_program_id, false).unwrap();
-        assert_eq!(identity(market.referrer_rebates_accrued), 32);
-        assert_eq!(identity(market.pc_fees_accrued), 128);
+        assert_eq!(identity(market.referrer_rebates_accrued), 400);
+        assert_eq!(identity(market.pc_fees_accrued), 1);
         assert_eq!(
             market.pc_fees_accrued + market.pc_deposits_total + market.referrer_rebates_accrued,
             520_000
@@ -365,8 +365,8 @@ fn test_new_order() {
             .unwrap();
         assert_eq!(identity(open_orders_seller.native_coin_free), 0);
         assert_eq!(identity(open_orders_seller.native_coin_total), 0);
-        assert_eq!(identity(open_orders_seller.native_pc_free), 399840);
-        assert_eq!(identity(open_orders_seller.native_pc_total), 399840);
+        assert_eq!(identity(open_orders_seller.native_pc_free), 399200);
+        assert_eq!(identity(open_orders_seller.native_pc_total), 399200);
     }
 
     {
@@ -386,8 +386,8 @@ fn test_new_order() {
 
     {
         let market = Market::load(&accounts.market, &dex_program_id, false).unwrap();
-        assert_eq!(identity(market.referrer_rebates_accrued), 32);
-        assert_eq!(identity(market.pc_fees_accrued), 128);
+        assert_eq!(identity(market.referrer_rebates_accrued), 400);
+        assert_eq!(identity(market.pc_fees_accrued), 1);
         assert_eq!(
             market.pc_deposits_total + market.pc_fees_accrued + market.referrer_rebates_accrued,
             520_000
@@ -400,16 +400,16 @@ fn test_new_order() {
             .unwrap();
         assert_eq!(identity(open_orders_buyer.native_coin_free), 4_000);
         assert_eq!(identity(open_orders_buyer.native_coin_total), 4_000);
-        assert_eq!(identity(open_orders_buyer.native_pc_free), 20_000);
-        assert_eq!(identity(open_orders_buyer.native_pc_total), 120_000);
+        assert_eq!(identity(open_orders_buyer.native_pc_free), 20_399);
+        assert_eq!(identity(open_orders_buyer.native_pc_total), 120_399);
         let open_orders_seller = Market::load(&accounts.market, &dex_program_id, false)
             .unwrap()
             .load_orders_mut(&orders_account_seller, None, &dex_program_id, None, None)
             .unwrap();
         assert_eq!(identity(open_orders_seller.native_coin_free), 0);
         assert_eq!(identity(open_orders_seller.native_coin_total), 0);
-        assert_eq!(identity(open_orders_seller.native_pc_free), 399_840);
-        assert_eq!(identity(open_orders_seller.native_pc_total), 399_840);
+        assert_eq!(identity(open_orders_seller.native_pc_free), 399_200);
+        assert_eq!(identity(open_orders_seller.native_pc_total), 399_200);
     }
 }
 
@@ -421,6 +421,12 @@ fn test_cancel_orders() {
     let accounts = setup_market(&mut rng, &bump);
 
     let dex_program_id = accounts.market.owner;
+
+    {
+        let market = Market::load(&accounts.market, &dex_program_id, false).unwrap();
+        assert_eq!(identity(market.pc_fees_accrued), 0);
+        assert_eq!(identity(market.pc_deposits_total), 0);
+    }
 
     let owner = new_sol_account(&mut rng, 1_000_000_000, &bump);
     let orders_account =


### PR DESCRIPTION
* remove SRM/MSRM fee discount
* fee tiers purely based on market ids
* 3 tiers: Base, Flagship, Stable
* 99.9% of fees paid out to maker & gui, only dust reamins