### PR TITLE
fix compilation error by adding missing crate feature

### DIFF
--- a/dex/crank/Cargo.toml
+++ b/dex/crank/Cargo.toml
@@ -8,7 +8,7 @@ name = "crank"
 path = "src/bin/main.rs"
 
 [dependencies]
-serum_dex = { path = "../", default-features = false, features = ["client"] }
+serum_dex = { path = "../", default-features = false, features = ["client", "program"] }
 serum-common = { path = "../../common", features = ["client"] }
 spl-token = { version = "3.0.0-pre1", features = ["no-entrypoint"], default-features = false }
 clap = { version = "3.1.6", features = ["derive"] }


### PR DESCRIPTION
## Problem 

 `process_new_order_v3` method is available only for feature `program`.
crank depends on serum_dex crate, but doesn't use aforementioned feature and, hence, fails with error:
```bash
Self::process_new_order_v3,
     |                       ^^^^^^^^^^^^^^^^^^^^
     |                       |
     |                       variant or associated item not found in `state::State`
     |                       help: there is an associated function with a similar name: `process_cancel_order_v2`
```

## Solution

Add the missing feature to Cargo.toml