### PR TITLE
Add CI script to create Anchor Verifiable Builds

### DIFF
--- a/.github/workflows/ci-verifiable-build.yml
+++ b/.github/workflows/ci-verifiable-build.yml
@@ -13,7 +13,7 @@ env:
 
 defaults:
   run:
-    working-directory: ./
+    working-directory: ./dex
 
 jobs:
   build:
@@ -30,11 +30,12 @@ jobs:
 
       - name: Verifiable Build
         run: |
-          cd dex
           echo "APP_NAME=$(cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[0].name')" >> $GITHUB_ENV 
           anchor build --docker-image projectserum/build:v${{ env.ANCHOR_BUILD_IMAGE_VERSION }} --verifiable
+
+      - name: Generate Checksum
+        run: |
           echo "CHECKSUM=$(sha256sum ./target/verifiable/${{ env.APP_NAME }}.so | head -c 64)" >> $GITHUB_ENV
-          cd ../
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/ci-verifiable-build.yml
+++ b/.github/workflows/ci-verifiable-build.yml
@@ -1,0 +1,66 @@
+name: Verifiable Build
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  # Anchor 0.25.0 (latest) does not include x86_64 binary, use older version until resolved https://github.com/coral-xyz/anchor/issues/2076
+  ANCHOR_CLI_VERSION: 0.24.2
+  # TODO: Anchor build image version is set manually. Should read from Anchor.toml once this version is decided upon
+  ANCHOR_BUILD_IMAGE_VERSION: 0.25.0
+
+defaults:
+  run:
+    working-directory: ./
+
+jobs:
+  build:
+    name: Build Verifiable Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Anchor CLI
+        run: |
+          npm install -g @project-serum/anchor-cli@${{ env.ANCHOR_CLI_VERSION }}
+          anchor --version
+
+      - name: Install Cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Verifiable Build
+        run: |
+          cd dex
+          echo "APP_NAME=$(cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[0].name')" >> $GITHUB_ENV 
+          anchor build --docker-image projectserum/build:v${{ env.ANCHOR_BUILD_IMAGE_VERSION }} --verifiable
+          echo "CHECKSUM=$(sha256sum ./target/verifiable/${{ env.APP_NAME }}.so | head -c 64)" >> $GITHUB_ENV 
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          body: |
+            sha256 checksum: ${{ env.CHECKSUM }}
+            github commit: ${{ github.sha }}
+
+      - name: Upload Build Artifact
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/verifiable/${{ env.APP_NAME }}.so
+          asset_name: ${{ env.APP_NAME }}.so
+          asset_content_type: application/x-sharedlib
+

--- a/.github/workflows/ci-verifiable-build.yml
+++ b/.github/workflows/ci-verifiable-build.yml
@@ -5,7 +5,6 @@ on:
       - "v*"
 
 env:
-  CARGO_TERM_COLOR: always
   # Anchor 0.25.0 (latest) does not include x86_64 binary, use older version until resolved https://github.com/coral-xyz/anchor/issues/2076
   ANCHOR_CLI_VERSION: 0.24.2
   # TODO: Anchor build image version is set manually. Should read from Anchor.toml once this version is decided upon

--- a/.github/workflows/ci-verifiable-build.yml
+++ b/.github/workflows/ci-verifiable-build.yml
@@ -7,8 +7,6 @@ on:
 env:
   # Anchor 0.25.0 (latest) does not include x86_64 binary, use older version until resolved https://github.com/coral-xyz/anchor/issues/2076
   ANCHOR_CLI_VERSION: 0.24.2
-  # TODO: Anchor build image version is set manually. Should read from Anchor.toml once this version is decided upon
-  ANCHOR_BUILD_IMAGE_VERSION: 0.25.0
 
 defaults:
   run:
@@ -30,7 +28,7 @@ jobs:
       - name: Verifiable Build
         run: |
           echo "APP_NAME=$(cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[0].name')" >> $GITHUB_ENV 
-          anchor build --docker-image projectserum/build:v${{ env.ANCHOR_BUILD_IMAGE_VERSION }} --verifiable
+          anchor build --verifiable
 
       - name: Generate Checksum
         run: |

--- a/.github/workflows/ci-verifiable-build.yml
+++ b/.github/workflows/ci-verifiable-build.yml
@@ -54,6 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./target/verifiable/${{ env.APP_NAME }}.so
+          # default working directory only applies to 'run' steps, hardcoded workspace path for now
+          asset_path: ./dex/target/verifiable/${{ env.APP_NAME }}.so
           asset_name: ${{ env.APP_NAME }}.so
           asset_content_type: application/x-sharedlib

--- a/.github/workflows/ci-verifiable-build.yml
+++ b/.github/workflows/ci-verifiable-build.yml
@@ -2,7 +2,7 @@ name: Verifiable Build
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 env:
   CARGO_TERM_COLOR: always
@@ -28,18 +28,13 @@ jobs:
           npm install -g @project-serum/anchor-cli@${{ env.ANCHOR_CLI_VERSION }}
           anchor --version
 
-      - name: Install Cargo
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-
       - name: Verifiable Build
         run: |
           cd dex
           echo "APP_NAME=$(cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[0].name')" >> $GITHUB_ENV 
           anchor build --docker-image projectserum/build:v${{ env.ANCHOR_BUILD_IMAGE_VERSION }} --verifiable
-          echo "CHECKSUM=$(sha256sum ./target/verifiable/${{ env.APP_NAME }}.so | head -c 64)" >> $GITHUB_ENV 
+          echo "CHECKSUM=$(sha256sum ./target/verifiable/${{ env.APP_NAME }}.so | head -c 64)" >> $GITHUB_ENV
+          cd ../
 
       - name: Create Release
         id: create_release
@@ -54,7 +49,6 @@ jobs:
             github commit: ${{ github.sha }}
 
       - name: Upload Build Artifact
-        id: upload-release-asset 
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,4 +57,3 @@ jobs:
           asset_path: ./target/verifiable/${{ env.APP_NAME }}.so
           asset_name: ${{ env.APP_NAME }}.so
           asset_content_type: application/x-sharedlib
-

--- a/dex/Anchor.toml
+++ b/dex/Anchor.toml
@@ -1,4 +1,4 @@
-anchor_version = "0.18.2"
+anchor_version = "0.25.0"
 
 [workspace]
 members = [


### PR DESCRIPTION
This script runs `anchor build --verifiable` when a new version is tagged, and creates a Github release with the build artifact and SHA256 checksum.

Example run: https://github.com/riordanp/openbook-dex/actions/runs/3570164791/jobs/6000876012
Example release: https://github.com/riordanp/openbook-dex/releases/tag/v4.2.4