### PR TITLE
chore: fix wrong expected value for referrer_rebates_accrued expected in test_new_order

### DIFF
--- a/dex/src/tests.rs
+++ b/dex/src/tests.rs
@@ -343,7 +343,7 @@ fn test_new_order() {
 
     {
         let market = Market::load(&accounts.market, &dex_program_id, false).unwrap();
-        assert_eq!(identity(market.referrer_rebates_accrued), 400);
+        assert_eq!(identity(market.referrer_rebates_accrued), 80);
         assert_eq!(identity(market.pc_fees_accrued), 1);
         assert_eq!(
             market.pc_fees_accrued + market.pc_deposits_total + market.referrer_rebates_accrued,


### PR DESCRIPTION
seems https://github.com/openbook-dex/program/pull/19 broke `test_new_order`. fix it to the correct expected value.