### PR TITLE
make GITHUB_SHA and GITHUB_REF_NAME optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f215f9b7224f49fb73256115331f677d868b34d18b65dbe4db392e6021eea90"
 
 [[package]]
+name = "default-env"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f753eb82d29277e79efc625e84aecacfd4851ee50e05a8573a4740239a77bfd3"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,6 +3486,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "byteorder",
+ "default-env",
  "enumflags2",
  "field-offset",
  "itertools 0.9.0",

--- a/dex/Cargo.lock
+++ b/dex/Cargo.lock
@@ -551,6 +551,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "default-env"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f753eb82d29277e79efc625e84aecacfd4851ee50e05a8573a4740239a77bfd3"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
 name = "derivative"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1418,7 @@ dependencies = [
  "bumpalo",
  "bytemuck",
  "byteorder",
+ "default-env",
  "enumflags2",
  "field-offset",
  "hexdump",

--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -35,6 +35,7 @@ num-traits = "0.2.12"
 arrayref = "0.3.6"
 bytemuck = { version = "1.4.0" }
 byteorder = "1.3.4"
+default-env = "0.1.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/dex/src/lib.rs
+++ b/dex/src/lib.rs
@@ -35,7 +35,7 @@ fn process_instruction(
 }
 
 #[cfg(not(feature = "no-entrypoint"))]
-use solana_security_txt::security_txt;
+use {default_env::default_env, solana_security_txt::security_txt};
 #[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     // Required fields
@@ -47,6 +47,6 @@ security_txt! {
     // Optional Fields
     preferred_languages: "en",
     source_code: "https://github.com/openbook-dex/program",
-    source_revision: env!("GITHUB_SHA"),
-    source_release: env!("GITHUB_REF_NAME")
+    source_revision: default_env!("GITHUB_SHA", "unknown source revision"),
+    source_release: default_env!("GITHUB_REF_NAME", "unknown source release")
 }


### PR DESCRIPTION
#### Problem

`GITHUB_SHA` and `GITHUB_REF_NAME` are not actually optional atm. It will report error if we don't define them.

#### Changes

use default_env to make them optional

btw, I think we can add test cases for this when the upstream project merge https://www.github.com/neodyme-labs/solana-security-txt/pull/23.