### PR TITLE
chore: replace `serum` -> `openbook` in code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d6c8fbc834319618581a4e19807a30e76326b9981abd069addb55acf0647db"
 dependencies = [
  "anchor-lang 0.18.2",
- "serum_dex 0.4.0",
+ "serum_dex",
  "solana-program",
  "spl-associated-token-account",
  "spl-token 3.5.0",
@@ -1013,10 +1013,10 @@ dependencies = [
  "debug_print",
  "enumflags2",
  "log",
+ "openbook-common",
+ "openbook_dex",
  "rand 0.7.3",
  "safe-transmute",
- "serum-common",
- "serum_dex 0.5.10",
  "slog-scope",
  "slog-stdlog",
  "sloggers",
@@ -2542,6 +2542,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openbook-common"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "arrayref",
+ "bincode",
+ "bs58 0.4.0",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serum-borsh",
+ "solana-client",
+ "solana-program",
+ "solana-sdk",
+ "spl-token 2.0.8",
+]
+
+[[package]]
+name = "openbook-dex-permissioned"
+version = "0.5.1"
+dependencies = [
+ "anchor-lang 0.18.2",
+ "anchor-spl",
+ "openbook_dex",
+ "spl-token 3.5.0",
+]
+
+[[package]]
+name = "openbook_assert_owner"
+version = "0.1.0"
+dependencies = [
+ "solana-program",
+]
+
+[[package]]
+name = "openbook_dex"
+version = "0.5.10"
+dependencies = [
+ "anchor-lang 0.25.0",
+ "arrayref",
+ "bincode",
+ "bytemuck",
+ "byteorder",
+ "default-env",
+ "enumflags2",
+ "field-offset",
+ "itertools 0.10.5",
+ "num-traits",
+ "num_enum",
+ "safe-transmute",
+ "serde",
+ "solana-program",
+ "solana-security-txt",
+ "spl-token 3.5.0",
+ "static_assertions",
+ "thiserror",
+ "without-alloc",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,41 +3419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serum-common"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "arrayref",
- "bincode",
- "bs58 0.4.0",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serum-borsh",
- "solana-client",
- "solana-program",
- "solana-sdk",
- "spl-token 2.0.8",
-]
-
-[[package]]
-name = "serum-dex-permissioned"
-version = "0.5.1"
-dependencies = [
- "anchor-lang 0.18.2",
- "anchor-spl",
- "serum_dex 0.5.10",
- "spl-token 3.5.0",
-]
-
-[[package]]
-name = "serum_assert_owner"
-version = "0.1.0"
-dependencies = [
- "solana-program",
-]
-
-[[package]]
 name = "serum_dex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,31 +3436,6 @@ dependencies = [
  "safe-transmute",
  "serde",
  "solana-program",
- "spl-token 3.5.0",
- "static_assertions",
- "thiserror",
- "without-alloc",
-]
-
-[[package]]
-name = "serum_dex"
-version = "0.5.10"
-dependencies = [
- "anchor-lang 0.25.0",
- "arrayref",
- "bincode",
- "bytemuck",
- "byteorder",
- "default-env",
- "enumflags2",
- "field-offset",
- "itertools 0.10.5",
- "num-traits",
- "num_enum",
- "safe-transmute",
- "serde",
- "solana-program",
- "solana-security-txt",
  "spl-token 3.5.0",
  "static_assertions",
  "thiserror",

--- a/assert-owner/Cargo.toml
+++ b/assert-owner/Cargo.toml
@@ -1,9 +1,9 @@
 # Note: This crate must be built using do.sh
 
 [package]
-name = "serum_assert_owner"
+name = "openbook_assert_owner"
 version = "0.1.0"
-repository = "https://github.com/project-serum/serum-dex"
+repository = "https://github.com/openbook-dex/program"
 edition = "2018"
 
 [dependencies]
@@ -11,6 +11,6 @@ solana-program = "1.10.41"
 
 [lib]
 crate-type = ["cdylib", "lib"]
-name = "serum_assert_owner"
+name = "openbook_assert_owner"
 
 [dev-dependencies]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "serum-common"
+name = "openbook-common"
 version = "0.1.0"
-description = "Serum common utilities"
-repository = "https://github.com/project-serum/serum-dex"
+description = "Openbook common utilities"
+repository = "https://github.com/openbook-dex/program"
 edition = "2018"
 
 [features]

--- a/dex/Anchor.toml
+++ b/dex/Anchor.toml
@@ -10,4 +10,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [programs.mainnet]
-serum_dex = "srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX"
+openbook_dex = "srmqPvymJeFKQ4zGQed1GFppgkRHL9kaELCbyksJtPX"

--- a/dex/Cargo.lock
+++ b/dex/Cargo.lock
@@ -971,6 +971,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openbook_dex"
+version = "0.5.10"
+dependencies = [
+ "anchor-lang",
+ "arbitrary",
+ "arrayref",
+ "bincode",
+ "bumpalo",
+ "bytemuck",
+ "byteorder",
+ "default-env",
+ "enumflags2",
+ "field-offset",
+ "hexdump",
+ "itertools 0.10.5",
+ "num-traits",
+ "num_enum",
+ "proptest",
+ "proptest-derive",
+ "rand 0.7.3",
+ "safe-transmute",
+ "serde",
+ "solana-program",
+ "solana-security-txt",
+ "spl-token",
+ "static_assertions",
+ "thiserror",
+ "without-alloc",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,37 +1426,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serum_dex"
-version = "0.5.10"
-dependencies = [
- "anchor-lang",
- "arbitrary",
- "arrayref",
- "bincode",
- "bumpalo",
- "bytemuck",
- "byteorder",
- "default-env",
- "enumflags2",
- "field-offset",
- "hexdump",
- "itertools 0.10.5",
- "num-traits",
- "num_enum",
- "proptest",
- "proptest-derive",
- "rand 0.7.3",
- "safe-transmute",
- "serde",
- "solana-program",
- "solana-security-txt",
- "spl-token",
- "static_assertions",
- "thiserror",
- "without-alloc",
 ]
 
 [[package]]

--- a/dex/Cargo.toml
+++ b/dex/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "serum_dex"
+name = "openbook_dex"
 version = "0.5.10"
-description = "Serum DEX"
-repository = "https://github.com/project-serum/serum-dex"
+description = "Openbook DEX"
+repository = "https://github.com/openbook-dex/program"
 edition = "2018"
 license = "Apache-2.0"
-authors = ["Serum Foundation <foundation@projectserum.com>"]
+authors = ["Openbook Maintainers <contact@openbook-solana.com>"]
 
 [features]
 program = []

--- a/dex/README.md
+++ b/dex/README.md
@@ -19,7 +19,7 @@ cargo build --relase dex
 ### Deploy the dex to the configured solana cluster
 
 ```bash
-DEX_PROGRAM_ID="$(solana deploy ./target/bpfel-unknown-unknown/release/serum_dex.so | jq .programId -r)"
+DEX_PROGRAM_ID="$(solana deploy ./target/bpfel-unknown-unknown/release/openbook_dex.so | jq .programId -r)"
 ```
 
 ## Run the fuzz tests
@@ -80,7 +80,7 @@ NDEBUG=1 ./run.sh
 solana config set -u http://127.0.0.1:8899
 solana-keygen new
 solana airdrop 100
-DEX_PROGRAM_ID="$(solana deploy dex/target/bpfel-unknown-unknown/release/serum_dex.so | jq .programId -r)"
+DEX_PROGRAM_ID="$(solana deploy dex/target/bpfel-unknown-unknown/release/openbook_dex.so | jq .programId -r)"
 CLUSTER=localnet
 KEYPAIR=~/.config/solana/id.json
 

--- a/dex/crank/Cargo.toml
+++ b/dex/crank/Cargo.toml
@@ -8,8 +8,8 @@ name = "crank"
 path = "src/bin/main.rs"
 
 [dependencies]
-serum_dex = { path = "../", default-features = false, features = ["client", "program"] }
-serum-common = { path = "../../common", features = ["client"] }
+openbook_dex = { path = "../", default-features = false, features = ["client", "program"] }
+openbook-common = { path = "../../common", features = ["client"] }
 spl-token = { version = "3.5.0", features = ["no-entrypoint"], default-features = false }
 clap = { version = "4.0.29", features = ["derive"] }
 enumflags2 = "0.6.4"

--- a/dex/crank/src/lib.rs
+++ b/dex/crank/src/lib.rs
@@ -37,24 +37,24 @@ use solana_sdk::transaction::Transaction;
 use spl_token::instruction as token_instruction;
 use warp::Filter;
 
-use serum_common::client::rpc::{
+use openbook_common::client::rpc::{
     create_and_init_mint, create_token_account, mint_to_new_account, send_txn, simulate_transaction,
 };
-use serum_common::client::Cluster;
-use serum_dex::instruction::{
+use openbook_common::client::Cluster;
+use openbook_dex::instruction::{
     cancel_order_by_client_order_id as cancel_order_by_client_order_id_ix,
     cancel_orders_by_client_order_ids as cancel_orders_by_client_order_ids_ix,
     close_open_orders as close_open_orders_ix, init_open_orders as init_open_orders_ix,
     MarketInstruction, NewOrderInstructionV3, SelfTradeBehavior,
 };
-use serum_dex::matching::{OrderType, Side};
-use serum_dex::state::gen_vault_signer_key;
-use serum_dex::state::Event;
-use serum_dex::state::EventQueueHeader;
-use serum_dex::state::QueueHeader;
-use serum_dex::state::Request;
-use serum_dex::state::RequestQueueHeader;
-use serum_dex::state::{AccountFlag, Market, MarketState, MarketStateV2};
+use openbook_dex::matching::{OrderType, Side};
+use openbook_dex::state::gen_vault_signer_key;
+use openbook_dex::state::Event;
+use openbook_dex::state::EventQueueHeader;
+use openbook_dex::state::QueueHeader;
+use openbook_dex::state::Request;
+use openbook_dex::state::RequestQueueHeader;
+use openbook_dex::state::{AccountFlag, Market, MarketState, MarketStateV2};
 
 pub fn with_logging<F: FnOnce()>(_to: &str, fnc: F) {
     fnc();
@@ -392,7 +392,7 @@ pub struct MarketPubkeys {
 
 #[cfg(target_endian = "little")]
 fn remove_dex_account_padding<'a>(data: &'a [u8]) -> Result<Cow<'a, [u64]>> {
-    use serum_dex::state::{ACCOUNT_HEAD_PADDING, ACCOUNT_TAIL_PADDING};
+    use openbook_dex::state::{ACCOUNT_HEAD_PADDING, ACCOUNT_TAIL_PADDING};
     let head = &data[..ACCOUNT_HEAD_PADDING.len()];
     if data.len() < ACCOUNT_HEAD_PADDING.len() + ACCOUNT_TAIL_PADDING.len() {
         return Err(format_err!(
@@ -1107,7 +1107,7 @@ pub fn init_open_orders(
                 client,
                 program_id,
                 &owner.pubkey(),
-                size_of::<serum_dex::state::OpenOrders>(),
+                size_of::<openbook_dex::state::OpenOrders>(),
             )?;
             orders_keypair = orders_key;
             signers.push(&orders_keypair);
@@ -1156,7 +1156,7 @@ pub fn place_order(
                 client,
                 program_id,
                 &payer.pubkey(),
-                size_of::<serum_dex::state::OpenOrders>(),
+                size_of::<openbook_dex::state::OpenOrders>(),
             )?;
             orders_keypair = orders_key;
             signers.push(&orders_keypair);
@@ -1284,7 +1284,7 @@ pub fn list_market(
     let pc_vault = create_token_account(client, pc_mint, &listing_keys.vault_signer_pk, payer)?;
     debug_println!("Created account: {} ...", pc_vault.pubkey());
 
-    let init_market_instruction = serum_dex::instruction::initialize_market(
+    let init_market_instruction = openbook_dex::instruction::initialize_market(
         &market_key.pubkey(),
         program_id,
         coin_mint,

--- a/dex/fuzz/Cargo.lock
+++ b/dex/fuzz/Cargo.lock
@@ -911,6 +911,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openbook_dex"
+version = "0.5.10"
+dependencies = [
+ "anchor-lang",
+ "arbitrary",
+ "arrayref",
+ "bincode",
+ "bytemuck",
+ "byteorder",
+ "default-env",
+ "enumflags2",
+ "field-offset",
+ "itertools",
+ "num-traits",
+ "num_enum",
+ "safe-transmute",
+ "serde",
+ "solana-program",
+ "solana-security-txt",
+ "spl-token",
+ "static_assertions",
+ "thiserror",
+ "without-alloc",
+]
+
+[[package]]
+name = "openbook_dex-fuzz"
+version = "0.0.0"
+dependencies = [
+ "arbitrary",
+ "bumpalo",
+ "itertools",
+ "lazy_static",
+ "libfuzzer-sys",
+ "openbook_dex",
+ "rand",
+ "safe-transmute",
+ "solana-program",
+ "spl-token",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1231,48 +1273,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serum_dex"
-version = "0.5.10"
-dependencies = [
- "anchor-lang",
- "arbitrary",
- "arrayref",
- "bincode",
- "bytemuck",
- "byteorder",
- "default-env",
- "enumflags2",
- "field-offset",
- "itertools",
- "num-traits",
- "num_enum",
- "safe-transmute",
- "serde",
- "solana-program",
- "solana-security-txt",
- "spl-token",
- "static_assertions",
- "thiserror",
- "without-alloc",
-]
-
-[[package]]
-name = "serum_dex-fuzz"
-version = "0.0.0"
-dependencies = [
- "arbitrary",
- "bumpalo",
- "itertools",
- "lazy_static",
- "libfuzzer-sys",
- "rand",
- "safe-transmute",
- "serum_dex",
- "solana-program",
- "spl-token",
 ]
 
 [[package]]

--- a/dex/fuzz/Cargo.toml
+++ b/dex/fuzz/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "serum_dex-fuzz"
+name = "openbook_dex-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
@@ -19,7 +19,7 @@ rand = "0.7.3"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 
-[dependencies.serum_dex]
+[dependencies.openbook_dex]
 path = ".."
 features = ["fuzz", "program"]
 

--- a/dex/fuzz/fuzz_targets/multiple_orders.rs
+++ b/dex/fuzz/fuzz_targets/multiple_orders.rs
@@ -14,13 +14,13 @@ use lazy_static::lazy_static;
 use libfuzzer_sys::fuzz_target;
 use solana_program::account_info::AccountInfo;
 
-use serum_dex::error::{DexError, DexErrorCode};
-use serum_dex::instruction::{
+use openbook_dex::error::{DexError, DexErrorCode};
+use openbook_dex::instruction::{
     CancelOrderInstructionV2, MarketInstruction, NewOrderInstructionV3, SelfTradeBehavior,
 };
-use serum_dex::matching::Side;
-use serum_dex::state::{strip_header, Market, OpenOrders, ToAlignedBytes};
-use serum_dex_fuzz::{
+use openbook_dex::matching::Side;
+use openbook_dex::state::{strip_header, Market, OpenOrders, ToAlignedBytes};
+use openbook_dex_fuzz::{
     get_token_account_balance, new_dex_owned_account_with_lamports, new_sol_account,
     new_token_account, process_instruction, setup_market, MarketAccounts, NoSolLoggingStubs,
     COIN_LOT_SIZE, PC_LOT_SIZE,
@@ -245,7 +245,7 @@ fn run_actions(seq: ActionSequence) {
             market_accounts
                 .open_orders_authority
                 .as_ref()
-                .map(|acc| serum_dex::state::fuzz_account_parser::SignerAccount::new(acc).unwrap()),
+                .map(|acc| openbook_dex::state::fuzz_account_parser::SignerAccount::new(acc).unwrap()),
         );
         let open_orders = match load_orders_result {
             Err(e) if e == DexErrorCode::RentNotProvided.into() => {

--- a/dex/fuzz/src/lib.rs
+++ b/dex/fuzz/src/lib.rs
@@ -17,9 +17,9 @@ use solana_program::sysvar::Sysvar;
 use spl_token::state::Account as SplAccount;
 use spl_token::state::Mint;
 
-use serum_dex::error::DexResult;
-use serum_dex::instruction::{fee_sweeper, initialize_market};
-use serum_dex::state::{
+use openbook_dex::error::DexResult;
+use openbook_dex::instruction::{fee_sweeper, initialize_market};
+use openbook_dex::state::{
     gen_vault_signer_key, strip_header, EventQueue, MarketState, MarketStateV2, Queue,
     RequestQueue, State,
 };

--- a/dex/permissioned/Cargo.toml
+++ b/dex/permissioned/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "serum-dex-permissioned"
+name = "openbook-dex-permissioned"
 version = "0.5.1"
 edition = "2018"
 
 [dependencies]
 anchor-lang = "0.18.2"
 anchor-spl = { version = "0.18.2", features = ["dex"] }
-serum_dex = { path = "../", features = ["no-entrypoint"] }
+openbook_dex = { path = "../", features = ["no-entrypoint"] }
 spl-token = { version = "3.1.1", features = ["no-entrypoint"] }

--- a/dex/permissioned/src/lib.rs
+++ b/dex/permissioned/src/lib.rs
@@ -3,4 +3,4 @@ mod proxy;
 
 pub use middleware::*;
 pub use proxy::*;
-pub use serum_dex;
+pub use openbook_dex;

--- a/dex/permissioned/src/middleware.rs
+++ b/dex/permissioned/src/middleware.rs
@@ -4,9 +4,9 @@ use anchor_lang::solana_program::instruction::Instruction;
 use anchor_lang::solana_program::system_program;
 use anchor_lang::Accounts;
 use anchor_spl::{dex, token};
-use serum_dex::instruction::*;
-use serum_dex::matching::Side;
-use serum_dex::state::OpenOrders;
+use openbook_dex::instruction::*;
+use openbook_dex::matching::Side;
+use openbook_dex::state::OpenOrders;
 use std::mem::size_of;
 
 /// Per request context. Can be used to share data between middleware handlers.
@@ -53,7 +53,7 @@ impl<'a, 'info> Context<'a, 'info> {
     }
 }
 
-/// Implementing this trait allows one to hook into requests to the Serum DEX
+/// Implementing this trait allows one to hook into requests to the Openbook DEX
 /// via a frontend proxy.
 pub trait MarketMiddleware {
     /// Called before any instruction, giving middleware access to the raw
@@ -156,7 +156,7 @@ impl MarketMiddleware for OpenOrdersPda {
     ///
     /// 0. Dex program.
     /// 1. System program.
-    /// .. serum_dex::MarketInstruction::InitOpenOrders.
+    /// .. openbook_dex::MarketInstruction::InitOpenOrders.
     ///
     /// Data:
     ///
@@ -463,7 +463,7 @@ impl ReferralFees {
 impl MarketMiddleware for ReferralFees {
     /// Accounts:
     ///
-    /// .. serum_dex::MarketInstruction::SettleFunds.
+    /// .. openbook_dex::MarketInstruction::SettleFunds.
     fn settle_funds(&self, ctx: &mut Context) -> ProgramResult {
         let referral = token::accessor::authority(&ctx.accounts[9])?;
         require!(referral == self.referral, ErrorCode::InvalidReferral);
@@ -542,7 +542,7 @@ macro_rules! open_orders_init_authority {
 
 #[error(offset = 500)]
 pub enum ErrorCode {
-    #[msg("Program ID does not match the Serum DEX")]
+    #[msg("Program ID does not match the Openbook DEX")]
     InvalidDexPid,
     #[msg("Invalid instruction given")]
     InvalidInstruction,
@@ -571,7 +571,7 @@ pub struct InitAccount<'info> {
         bump = bump,
         payer = authority,
         owner = dex::ID,
-        space = size_of::<OpenOrders>() + SERUM_PADDING,
+        space = size_of::<OpenOrders>() + OPENBOOK_PADDING,
     )]
     pub open_orders: AccountInfo<'info>,
     #[account(signer)]
@@ -587,7 +587,7 @@ pub struct InitAccount<'info> {
 
 // Constants.
 
-// Padding added to every serum account.
+// Padding added to every Openbook account.
 //
 // b"serum".len() + b"padding".len().
-const SERUM_PADDING: usize = 12;
+const OPENBOOK_PADDING: usize = 12;

--- a/dex/permissioned/src/proxy.rs
+++ b/dex/permissioned/src/proxy.rs
@@ -3,10 +3,10 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::program;
 use anchor_lang::solana_program::pubkey::Pubkey;
 use anchor_spl::dex;
-use serum_dex::instruction::*;
+use openbook_dex::instruction::*;
 
 /// MarketProxy provides an abstraction for implementing proxy programs to the
-/// Serum orderbook, allowing one to implement a middleware for the purposes
+/// Openbook orderbook, allowing one to implement a middleware for the purposes
 /// of intercepting and modifying requests before being relayed to the
 /// orderbook.
 ///
@@ -41,7 +41,7 @@ impl<'a> MarketProxy<'a> {
     ) -> ProgramResult {
         let mut ix_data = data;
 
-        // First account is the Serum DEX executable--used for CPI.
+        // First account is the Openbook DEX executable--used for CPI.
         let dex = &accounts[0];
         require!(dex.key == &dex::ID, ErrorCode::InvalidTargetProgram);
         let acc_infos = (accounts[1..]).to_vec();

--- a/dex/src/critbit.rs
+++ b/dex/src/critbit.rs
@@ -288,7 +288,7 @@ impl Slab {
     /// ```compile_fail
     /// let slab = {
     ///     let mut bytes = [10; 100];
-    ///     serum_dex::critbit::Slab::new(&mut bytes)
+    ///     openbook_dex::critbit::Slab::new(&mut bytes)
     /// };
     /// ```
     #[inline]

--- a/dex/src/state.rs
+++ b/dex/src/state.rs
@@ -1642,7 +1642,7 @@ pub(crate) mod account_parser {
     pub struct InitializeMarketArgs<'a, 'b: 'a> {
         pub program_id: &'a Pubkey,
         pub instruction: &'a InitializeMarketInstruction,
-        serum_dex_accounts: &'a [AccountInfo<'b>; 5],
+        openbook_dex_accounts: &'a [AccountInfo<'b>; 5],
         pub coin_vault_and_mint: TokenAccountAndMint<'a, 'b>,
         pub pc_vault_and_mint: TokenAccountAndMint<'a, 'b>,
         pub market_authority: Option<&'a AccountInfo<'b>>,
@@ -1658,7 +1658,7 @@ pub(crate) mod account_parser {
         ) -> DexResult<Self> {
             check_assert!(accounts.len() >= 10 && accounts.len() <= 13)?;
             let (
-                unchecked_serum_dex_accounts,
+                unchecked_openbook_dex_accounts,
                 unchecked_vaults,
                 unchecked_mints,
                 unchecked_rent,
@@ -1686,7 +1686,7 @@ pub(crate) mod account_parser {
             }
 
             let mut checked_vaults = [None, None];
-            for account in unchecked_serum_dex_accounts {
+            for account in unchecked_openbook_dex_accounts {
                 check_assert_eq!(account.owner, program_id)?;
                 let data = account.try_borrow_data()?;
                 check_assert_eq!(data.len() % 8, 4)?;
@@ -1696,10 +1696,10 @@ pub(crate) mod account_parser {
                 check_assert_eq!(*header, [0u8; 8])?;
                 check_assert_eq!(*padding7, [0u8; 7])?;
             }
-            let serum_dex_accounts = unchecked_serum_dex_accounts;
+            let openbook_dex_accounts = unchecked_openbook_dex_accounts;
             let vault_owner_key_bytes = gen_vault_signer_key(
                 instruction.vault_signer_nonce,
-                serum_dex_accounts[0].key,
+                openbook_dex_accounts[0].key,
                 program_id,
             )?
             .to_bytes();
@@ -1730,7 +1730,7 @@ pub(crate) mod account_parser {
             Ok(InitializeMarketArgs {
                 program_id,
                 instruction,
-                serum_dex_accounts,
+                openbook_dex_accounts,
                 coin_vault_and_mint,
                 pc_vault_and_mint,
                 market_authority,
@@ -1740,23 +1740,23 @@ pub(crate) mod account_parser {
         }
 
         pub fn get_market(&self) -> &'a AccountInfo<'b> {
-            &self.serum_dex_accounts[0]
+            &self.openbook_dex_accounts[0]
         }
 
         pub fn get_req_q(&self) -> &'a AccountInfo<'b> {
-            &self.serum_dex_accounts[1]
+            &self.openbook_dex_accounts[1]
         }
 
         pub fn get_event_q(&self) -> &'a AccountInfo<'b> {
-            &self.serum_dex_accounts[2]
+            &self.openbook_dex_accounts[2]
         }
 
         pub fn get_bids(&self) -> &'a AccountInfo<'b> {
-            &self.serum_dex_accounts[3]
+            &self.openbook_dex_accounts[3]
         }
 
         pub fn get_asks(&self) -> &'a AccountInfo<'b> {
-            &self.serum_dex_accounts[4]
+            &self.openbook_dex_accounts[4]
         }
     }
 
@@ -2931,7 +2931,7 @@ impl State {
                 &mut event_q,
             ) {
                 // Cancel returns OrderNotFound when the order isn't in bids or
-                // asks. In this case, no Serum state is modified so it is safe
+                // asks. In this case, no Openbook state is modified so it is safe
                 // to continue. Any other type of error could be accompanied by
                 // a partial state change, so we must error. For example, if the
                 // event queue is full, we should abort to prevent the cancelled

--- a/dex/tests/permissioned/Anchor.toml
+++ b/dex/tests/permissioned/Anchor.toml
@@ -7,7 +7,7 @@ permissioned_markets = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
 
 [[test.genesis]]
 address = "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
-program = "../../target/deploy/serum_dex.so"
+program = "../../target/deploy/openbook_dex.so"
 
 [scripts]
 test = "npx mocha -t 1000000 tests/"

--- a/dex/tests/permissioned/package.json
+++ b/dex/tests/permissioned/package.json
@@ -1,7 +1,7 @@
 {
   "name": "permissioned-markets",
   "version": "1.0.0",
-  "description": "This repo demonstrates how to create \"permissioned markets\" on Serum via a proxy smart contract. A permissioned market is a regular Serum market with an additional open orders authority, which must sign every transaction to create an open orders account.",
+  "description": "This repo demonstrates how to create \"permissioned markets\" on Openbook via a proxy smart contract. A permissioned market is a regular Openbook market with an additional open orders authority, which must sign every transaction to create an open orders account.",
   "main": "index.js",
   "directories": {
     "test": "tests"

--- a/dex/tests/permissioned/programs/permissioned-markets/Cargo.toml
+++ b/dex/tests/permissioned/programs/permissioned-markets/Cargo.toml
@@ -17,6 +17,6 @@ default = []
 [dependencies]
 anchor-lang = "0.18.2"
 anchor-spl = { version = "0.18.2", features = ["dex"] }
-serum_dex = { path = "../../../../" }
-serum-dex-permissioned = { path = "../../../../permissioned" }
+openbook_dex = { path = "../../../../" }
+openbook-dex-permissioned = { path = "../../../../permissioned" }
 solana-program = "1.8.0"

--- a/dex/tests/permissioned/programs/permissioned-markets/src/lib.rs
+++ b/dex/tests/permissioned/programs/permissioned-markets/src/lib.rs
@@ -1,10 +1,10 @@
-// Note. This example depends on unreleased Serum DEX changes.
+// Note. This example depends on unreleased Openbook DEX changes.
 
 use anchor_lang::prelude::*;
-use serum_dex_permissioned::serum_dex::instruction::{
+use openbook_dex_permissioned::openbook_dex::instruction::{
     CancelOrderInstructionV2, NewOrderInstructionV3,
 };
-use serum_dex_permissioned::{
+use openbook_dex_permissioned::{
     Context, Logger, MarketMiddleware, MarketProxy, OpenOrdersPda, ReferralFees,
 };
 use solana_program::account_info::AccountInfo;
@@ -16,8 +16,8 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 /// # Permissioned Markets
 ///
-/// This demonstrates how to create "permissioned markets" on Serum via a proxy.
-/// A permissioned market is a regular Serum market with an additional
+/// This demonstrates how to create "permissioned markets" on Openbook via a proxy.
+/// A permissioned market is a regular Openbook market with an additional
 /// open orders authority, which must sign every transaction to create an open
 /// orders account.
 ///

--- a/scripts/travis/dex-tests.sh
+++ b/scripts/travis/dex-tests.sh
@@ -8,7 +8,7 @@ CLUSTER_URL=http://localhost:8899
 PROGRAM_ID="2SXFv8tTmavm8uSAg3ft1JjttzJvgwXZiUPa9xuUbqH2"
 
 #
-# Assumes the current working directory is top-level serum-dex dir.
+# Assumes the current working directory is top-level program dir.
 #
 main() {
     set +e
@@ -19,7 +19,7 @@ main() {
     #
     # Start the local validator.
     #
-    solana-test-validator --bpf-program $PROGRAM_ID dex/target/deploy/serum_dex.so > validator.log &
+    solana-test-validator --bpf-program $PROGRAM_ID dex/target/deploy/openbook_dex.so > validator.log &
     #
     # Wait for the validator to start.
     #


### PR DESCRIPTION
- replace references to `serum` with references to `openbook`